### PR TITLE
Add DCM pole placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Stabilizer: alternative DCM gain tuning by pole placement under ZMP lag model
+
 ### Changed
 
 - Switch license to BSD 2-clause for compatibility with other mc\_rtc projects

--- a/include/lipm_walking/Stabilizer.h
+++ b/include/lipm_walking/Stabilizer.h
@@ -389,6 +389,7 @@ namespace lipm_walking
     Eigen::Vector3d zmpccCoMOffset_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d zmpccCoMVel_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d zmpccError_ = Eigen::Vector3d::Zero();
+    Eigen::Vector4d poleAssignment_ = {-1., -1., -1., 1.}; /**< Pole assignment with ZMP delay (Morisawa et al., 2014) */
     ExponentialMovingAverage dcmIntegrator_;
     FDQPWeights fdqpWeights_;
     LeakyIntegrator zmpccIntegrator_;

--- a/include/lipm_walking/Stabilizer.h
+++ b/include/lipm_walking/Stabilizer.h
@@ -63,9 +63,9 @@ namespace lipm_walking
     /* Maximum gains in standing static equilibrium. */
     static constexpr double MAX_COM_ADMITTANCE = 20;
     static constexpr double MAX_COP_ADMITTANCE = 0.1;
-    static constexpr double MAX_DCM_D_GAIN = 10.;
-    static constexpr double MAX_DCM_I_GAIN = 30.;
-    static constexpr double MAX_DCM_P_GAIN = 10.;
+    static constexpr double MAX_DCM_D_GAIN = 2.;
+    static constexpr double MAX_DCM_I_GAIN = 100.;
+    static constexpr double MAX_DCM_P_GAIN = 20.;
     static constexpr double MAX_DFZ_ADMITTANCE = 5e-4;
     static constexpr double MAX_DFZ_DAMPING = 10.;
 
@@ -389,7 +389,7 @@ namespace lipm_walking
     Eigen::Vector3d zmpccCoMOffset_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d zmpccCoMVel_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d zmpccError_ = Eigen::Vector3d::Zero();
-    Eigen::Vector4d polePlacement_ = {-1., -1., -1., 1.}; /**< Pole placement with ZMP delay (Morisawa et al., 2014) */
+    Eigen::Vector4d polePlacement_ = {-10., -5., -1., 10.}; /**< Pole placement with ZMP delay (Morisawa et al., 2014) */
     ExponentialMovingAverage dcmIntegrator_;
     FDQPWeights fdqpWeights_;
     LeakyIntegrator zmpccIntegrator_;

--- a/include/lipm_walking/Stabilizer.h
+++ b/include/lipm_walking/Stabilizer.h
@@ -389,7 +389,7 @@ namespace lipm_walking
     Eigen::Vector3d zmpccCoMOffset_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d zmpccCoMVel_ = Eigen::Vector3d::Zero();
     Eigen::Vector3d zmpccError_ = Eigen::Vector3d::Zero();
-    Eigen::Vector4d poleAssignment_ = {-1., -1., -1., 1.}; /**< Pole assignment with ZMP delay (Morisawa et al., 2014) */
+    Eigen::Vector4d polePlacement_ = {-1., -1., -1., 1.}; /**< Pole placement with ZMP delay (Morisawa et al., 2014) */
     ExponentialMovingAverage dcmIntegrator_;
     FDQPWeights fdqpWeights_;
     LeakyIntegrator zmpccIntegrator_;

--- a/src/ModelPredictiveControl.cpp
+++ b/src/ModelPredictiveControl.cpp
@@ -243,8 +243,6 @@ namespace lipm_walking
   {
     hreps_[0] = initContact_.hrep();
     hreps_[2] = targetContact_.hrep();
-    //hreps_[1] = getDoubleSupportHrep(initContact_, targetContact_);
-    //hreps_[3] = getDoubleSupportHrep(targetContact_, nextContact_);
     unsigned totalRows = 0;
     for (long i = 0; i <= NB_STEPS; i++)
     {

--- a/src/Stabilizer.cpp
+++ b/src/Stabilizer.cpp
@@ -154,6 +154,26 @@ namespace lipm_walking
           dcmDerivGain_ = clamp(gains(2), 0., MAX_DCM_D_GAIN);
         }),
       ArrayInput(
+        "Pole assignment",
+        {"Pole1", "Pole2", "Pole3", "Lag freq. [Hz]"},
+        [this]() -> Eigen::VectorXd
+        {
+          return poleAssignment_;
+        },
+        [this](const Eigen::VectorXd & poleAssignment)
+        {
+          double alpha = clamp(poleAssignment(0), -20., -0.1);
+          double beta = clamp(poleAssignment(1), -20., -0.1);
+          double gamma = clamp(poleAssignment(2), -20., -0.1);
+          double lagFreq = clamp(poleAssignment(3), 0.1, 20.);
+          double omega = pendulum_.omega();
+          double denom = omega * lagFreq;
+          dcmDerivGain_ = -(alpha + beta + gamma + omega - lagFreq) / denom;
+          dcmIntegralGain_ = -(alpha * beta * gamma) / denom;
+          dcmPropGain_ = -(alpha * beta + beta * gamma + gamma * alpha + omega * lagFreq) / denom;
+          poleAssignment_ = {alpha, beta, gamma, lagFreq};
+        }),
+      ArrayInput(
         "DCM filters",
         {"Integrator T [s]", "Derivator T [s]"},
         [this]() -> Eigen::Vector2d

--- a/src/Stabilizer.cpp
+++ b/src/Stabilizer.cpp
@@ -170,7 +170,7 @@ namespace lipm_walking
           double denom = omega * lagFreq;
           dcmDerivGain_ = -(alpha + beta + gamma + omega - lagFreq) / denom;
           dcmIntegralGain_ = -(alpha * beta * gamma) / denom;
-          dcmPropGain_ = -(alpha * beta + beta * gamma + gamma * alpha + omega * lagFreq) / denom;
+          dcmPropGain_ = (alpha * beta + beta * gamma + gamma * alpha + omega * lagFreq) / denom;
           polePlacement_ = {alpha, beta, gamma, lagFreq};
         }),
       ArrayInput(

--- a/src/Stabilizer.cpp
+++ b/src/Stabilizer.cpp
@@ -154,24 +154,24 @@ namespace lipm_walking
           dcmDerivGain_ = clamp(gains(2), 0., MAX_DCM_D_GAIN);
         }),
       ArrayInput(
-        "Pole assignment",
+        "Pole placement with lag",
         {"Pole1", "Pole2", "Pole3", "Lag freq. [Hz]"},
         [this]() -> Eigen::VectorXd
         {
-          return poleAssignment_;
+          return polePlacement_;
         },
-        [this](const Eigen::VectorXd & poleAssignment)
+        [this](const Eigen::VectorXd & polePlacement)
         {
-          double alpha = clamp(poleAssignment(0), -20., -0.1);
-          double beta = clamp(poleAssignment(1), -20., -0.1);
-          double gamma = clamp(poleAssignment(2), -20., -0.1);
-          double lagFreq = clamp(poleAssignment(3), 0.1, 20.);
+          double alpha = clamp(polePlacement(0), -20., -0.1);
+          double beta = clamp(polePlacement(1), -20., -0.1);
+          double gamma = clamp(polePlacement(2), -20., -0.1);
+          double lagFreq = clamp(polePlacement(3), 0.1, 20.);
           double omega = pendulum_.omega();
           double denom = omega * lagFreq;
           dcmDerivGain_ = -(alpha + beta + gamma + omega - lagFreq) / denom;
           dcmIntegralGain_ = -(alpha * beta * gamma) / denom;
           dcmPropGain_ = -(alpha * beta + beta * gamma + gamma * alpha + omega * lagFreq) / denom;
-          poleAssignment_ = {alpha, beta, gamma, lagFreq};
+          polePlacement_ = {alpha, beta, gamma, lagFreq};
         }),
       ArrayInput(
         "DCM filters",

--- a/src/Stabilizer.cpp
+++ b/src/Stabilizer.cpp
@@ -168,7 +168,7 @@ namespace lipm_walking
           double lagFreq = clamp(polePlacement(3), 0.1, 20.);
           double omega = pendulum_.omega();
           double denom = omega * lagFreq;
-          dcmDerivGain_ = -(alpha + beta + gamma + omega - lagFreq) / denom;
+          dcmDerivGain_ = -(alpha + beta + gamma + lagFreq - omega) / denom;
           dcmIntegralGain_ = -(alpha * beta * gamma) / denom;
           dcmPropGain_ = (alpha * beta + beta * gamma + gamma * alpha + omega * lagFreq) / denom;
           polePlacement_ = {alpha, beta, gamma, lagFreq};

--- a/src/Stabilizer.cpp
+++ b/src/Stabilizer.cpp
@@ -172,13 +172,13 @@ namespace lipm_walking
           double denom = pendulum_.omega() * lagFreq;
           double T_integ = dcmIntegrator_.timeConstant();
 
-          // Gains K_z for the ZMP feedback (Delta ZMP = -K_z * Delta DCM)
+          // Gains K_z for the ZMP feedback (Delta ZMP = K_z * Delta DCM)
           double zmpPropGain = (alpha * beta + beta * gamma + gamma * alpha + omega * lagFreq) / denom;
           double zmpIntegralGain = -(alpha * beta * gamma) / denom;
           double zmpDerivGain = -(alpha + beta + gamma + lagFreq - omega) / denom;
 
           // Our gains K are for closed-loop DCM (Delta dot(DCM) = -K * Delta DCM)
-          dcmPropGain_ = omega * (1. + zmpPropGain);
+          dcmPropGain_ = omega * (zmpPropGain - 1.);
           dcmIntegralGain_ = omega * T_integ * zmpIntegralGain; // our integrator is an EMA
           dcmDerivGain_ = omega * zmpDerivGain;
         }),

--- a/src/states/CMakeLists.txt
+++ b/src/states/CMakeLists.txt
@@ -36,8 +36,6 @@ macro(add_fsm_state state_name state_SRC state_HDR)
   install(FILES ${state_HDR} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/mc_control/fsm/states)
 endmacro()
 
-# install(DIRECTORY data DESTINATION ${FSM_STATES_INSTALL_PREFIX} FILES_MATCHING PATTERN "*.json")
-
 macro(add_fsm_state_simple state_name)
   add_fsm_state(${state_name} ${state_name}.cpp ${state_name}.h)
 endmacro()


### PR DESCRIPTION
This PR provides an alternate computation of DCM feedback gains by pole placement of a reduced model with ZMP lag, as described in [Biped locomotion control for uneven terrain with narrow support region](https://doi.org/10.1109/SII.2014.7028007) (Morisawa _et al._, 2014).

We compared our DCM feedback gains after tuning on HRP-2Kai with those obtained by the authors of this work, and found that we both converged independently to the same proportional and derivative gains for this robot. Our integral gains differ, but our integrator (an exponential moving average) also differs from a straightforward one.

Pole placement is now available in the ``Advanced`` tab of the stabilizer in the GUI.